### PR TITLE
#153009253 Integrate Coveralls code coverage service

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: UBDSXQdylpVfGpRrxNQ0YHXaupoPydmCK

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ public/lib
 c4h_keys.txt
 .env
 package-lock.json
+coverage
+.nyc_output
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![](https://img.shields.io/badge/Protected_by-Hound-a873d1.svg)](https://houndci.com)
+[![](https://img.shields.io/badge/Protected_by-Hound-a873d1.svg)](https://houndci.com) [![Coverage Status](https://coveralls.io/repos/github/andela/k2-cfh/badge.svg?branch=chore%2F153009253%2Fintegrate-coveralls-code-coverage-service)](https://coveralls.io/github/andela/k2-cfh?branch=chore%2F153009253%2Fintegrate-coveralls-code-coverage-service)
 
 Cards for Humanity - [http://cfh.io](http://cfh.io)
 ===========

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   },
   "scripts": {
     "start": "node node_modules/grunt-cli/bin/grunt",
-    "test": "node node_modules/grunt-cli/bin/grunt test",
     "test:client": "karma start",
+    "test": "nyc --reporter=text --reporter=html node node_modules/grunt-cli/bin/grunt test",
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "postinstall": "node node_modules/grunt-cli/bin/grunt install"
   },
   "dependencies": {
@@ -48,6 +49,7 @@
     "view-helpers": "~0.1.3"
   },
   "devDependencies": {
+    "coveralls": "^3.0.0",
     "eslint": "^4.11.0",
     "eslint-cli": "^1.1.1",
     "eslint-config-airbnb": "^16.1.0",
@@ -64,6 +66,7 @@
     "karma": "^1.7.1",
     "karma-chrome-launcher": "^2.2.0",
     "karma-jasmine": "^1.1.0",
+    "nyc": "^11.3.0",
     "should": "~1.3.0",
     "supertest": "~0.8.0"
   }


### PR DESCRIPTION
#### What does this PR do?

Intergrate coveralls and code coverage service

#### Description of Task to be completed?

- Install nyc package
- Create a .coveralls.yml file in the project folder
- Obtain repo token from coveralls.io and add to .coveralls.yml file
- Update .gitignore file
- Create a script to run coverage in package.json file

#### How should this be manually tested?
- Clone the repository
- Run `git checkout chore/153009253/integrate-coveralls-code-coverage-service`
- Run `npm test`

#### Any background context you want to provide?

N/A
#### What are the relevant pivotal tracker stories?

- story type: chore
- story id: 153009253
- story title: Integrate Coveralls code coverage service

#### Screenshots (if appropriate)
<img width="1440" alt="screen shot 2017-11-22 at 3 07 34 pm" src="https://user-images.githubusercontent.com/4518420/33199933-c04d1350-d0f2-11e7-9b46-26d6ffe32f98.png">

#### Questions:

N/A