### PR TITLE
feeture(start game): user should be able to create/start game

### DIFF
--- a/app/controllers/gameHistory.js
+++ b/app/controllers/gameHistory.js
@@ -1,0 +1,102 @@
+/* eslint-disable */
+import gameHistory from '../models/gameHistory';
+
+/*
++ * Create New Game Record
++ */
+export const createGame = (request, response) => {
+    const games = new gameHistory();
+    games.gameID = request.params.id;
+    games.creator = request.body.creator;
+    games.players = request.body.players;
+    games.rounds = request.body.rounds;
+    games.winner = request.body.winner;
+    games.save((error, game) => {
+      if (error) {
+        response.status(400)
+          .json(error);
+      }
+      response.status(201)
+        .json(game);
+    });
+};
+
+/*
++ * Update Game Record
++ */
+export const updateGame = (request, response) => {
+  const gameCreator = request.body.creator;
+  const gameId = request.params.id;
+  const query = {
+    $and: [
+      { gameID: gameId }, { creator: gameCreator }
+    ]
+  }
+  gameHistory.findOne(query, (error, history) => {
+    if (error) {
+      return response.status(500)
+        .json({ message: 'An error occured while updating this data' });
+    }
+    if (!history) {
+      return response.status(404)
+        .json({ message: 'data not found' });
+    }
+
+    history.winner = request.body.winner;
+    history.ended = request.body.ended;
+    history.rounds = request.body.rounds;
+    history.save((error, history) => {
+      if (error) {
+        return response.status(500)
+          .json({ message: 'An error occured while updating this data' });
+      }
+      return response.status(200)
+        .json({ message: 'Game updated sucessfully', history });
+    });
+  });
+};
+
+/*
+ * Find Game Records by id
+ */
+export const getGame = (request, response) => {
+  gameHistory.findOne({
+    gameID: request.params.id
+  }, (error, savedGame) => {
+    if (error) {
+      response.send(error);
+    }
+    if (!savedGame) {
+      response.status(400)
+        .json({
+          success: false,
+          message: 'Game Record Not Found!!'
+        });
+    } else {
+      response.status(200)
+        .json(savedGame);
+    }
+  });
+};
+
+/*
+ * Find Game Records by id
+ */
+export const getAllGames = (request, response) => {
+  gameHistory.find({}, (error, savedGames) => {
+    if (error) {
+      response.status(404)
+        .json(error);
+    }
+    if (!savedGames) {
+      response.status(400)
+        .json({
+          success: false,
+          message: 'No Game Record Available!!'
+        });
+    } else {
+      response.status(200)
+        .json(savedGames);
+    }
+  });
+};

--- a/app/models/answer.js
+++ b/app/models/answer.js
@@ -2,14 +2,15 @@
 /**
  * Module dependencies.
  */
-var mongoose = require('mongoose'),
-  config = require('../../config/config'),
-  Schema = mongoose.Schema;
+import mongoose from 'mongoose';
+import config from '../../config/config';
+
+const Schema = mongoose.Schema;
 
 /**
  * Answer Schema
  */
-var AnswerSchema = new Schema({
+const AnswerSchema = new Schema({
   id: {
     type: Number
   },
@@ -32,11 +33,12 @@ var AnswerSchema = new Schema({
  * Statics
  */
 AnswerSchema.statics = {
-  load: function(id, cb) {
+  load: (id, cb) => {
     this.findOne({
       id: id
     }).select('-_id').exec(cb);
   }
 };
 
-mongoose.model('Answer', AnswerSchema);
+const AnswerModel = mongoose.model('Answer', AnswerSchema);
+export default AnswerModel;

--- a/app/models/gameHistory.js
+++ b/app/models/gameHistory.js
@@ -1,0 +1,20 @@
+/* eslint-disable */
+import mongoose from 'mongoose';
+import config from '../../config/config';
+
+const { Schema } = mongoose;
+
+/**
+ * Answer Schema
+ */
+const GameHistorySchema = new Schema({
+  gameID: { type: String, required: true },
+  logTime: { type: Date, default: Date.now },
+  rounds: { type: Number, default: 0 },
+  creator: { type: String, required: true },
+  winner: { type: String, default: '' },
+  players: { type: Array, default: [] },
+});
+
+// export model
+export default mongoose.model('GameHistory', GameHistorySchema);

--- a/app/models/question.js
+++ b/app/models/question.js
@@ -43,4 +43,6 @@ QuestionSchema.statics = {
   }
 };
 
-mongoose.model('Question', QuestionSchema);
+const QuestionModel = mongoose.model('Question', QuestionSchema);
+export default QuestionModel;
+ 

--- a/app/seeders/answers.js
+++ b/app/seeders/answers.js
@@ -1,0 +1,930 @@
+/* eslint-disable */
+import Answers from '../models/answer';
+
+const AnsersMigration = () => {
+  const answers = [
+    {
+      id: 1,
+      text: 'Soukous is to _ as Swahili is to _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 2,
+      text: 'czar is the coomon to _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Asia'
+    },
+    {
+      id: 3,
+      text: 'Africas are _ and Europeans are _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'America'
+    },
+    {
+      id: 4,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 6,
+      text: 'That is a new we _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 7,
+      text: 'This is a new them _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 8,
+      text: 'This is a new you _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 9,
+      text: 'This is a new me _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 10,
+      text: 'This is a new us _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 11,
+      text: 'Soukous is to _ as Swahili is to _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 12,
+      text: 'czar is the coomon to _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Asia'
+    },
+    {
+      id: 13,
+      text: 'Africas are _ and Europeans are _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'America'
+    },
+    {
+      id: 14,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 15,
+      text: 'That is a new we _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 17,
+      text: 'This is a new them _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 18,
+      text: 'This is a new you _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 19,
+      text: 'This is a new me _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 20,
+      text: 'This is a new us _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 21,
+      text: 'Soukous is to _ as Swahili is to _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 22,
+      text: 'czar is the coomon to _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Asia'
+    },
+    {
+      id: 23,
+      text: 'Africas are _ and Europeans are _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'America'
+    },
+    {
+      id: 24,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 25,
+      text: 'That is a new we _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 26,
+      text: 'That is a new we _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 27,
+      text: 'This is a new them _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 28,
+      text: 'This is a new you _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 29,
+      text: 'This is a new me _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 30,
+      text: 'This is a new us _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 31,
+      text: 'Soukous is to _ as Swahili is to _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 32,
+      text: 'czar is the coomon to _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Asia'
+    },
+    {
+      id: 33,
+      text: 'Africas are _ and Europeans are _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'America'
+    },
+    {
+      id: 34,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 35,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 36,
+      text: 'That is a new we _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 37,
+      text: 'This is a new them _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }, {
+      id: 38,
+      text: 'This is a new you _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }, {
+      id: 39,
+      text: 'This is a new me _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }, {
+      id: 40,
+      text: 'This is a new us _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 41,
+      text: 'Soukous is to _ as Swahili is to _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 42,
+      text: 'czar is the coomon to _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Asia'
+    },
+    {
+      id: 43,
+      text: 'Africas are _ and Europeans are _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'America'
+    },
+    {
+      id: 44,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 45,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 46,
+      text: 'That is a new we _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 47,
+      text: 'This is a new them _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }, {
+      id: 48,
+      text: 'This is a new you _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }, {
+      id: 49,
+      text: 'This is a new me _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }, {
+      id: 50,
+      text: 'This is a new us _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 51,
+      text: 'Soukous is to _ as Swahili is to _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 52,
+      text: 'czar is the coomon to _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Asia'
+    },
+    {
+      id: 53,
+      text: 'Africas are _ and Europeans are _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'America'
+    },
+    {
+      id: 54,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 55,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 56,
+      text: 'That is a new we _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 57,
+      text: 'This is a new them _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }, {
+      id: 58,
+      text: 'This is a new you _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 59,
+      text: 'This is a new me _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 60,
+      text: 'This is a new us _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 61,
+      text: 'Soukous is to _ as Swahili is to _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 61,
+      text: 'czar is the coomon to _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Asia'
+    },
+    {
+      id: 63,
+      text: 'Africas are _ and Europeans are _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'America'
+    },
+    {
+      id: 64,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 64,
+      text: 'That is a new we _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 67,
+      text: 'This is a new them _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 68,
+      text: 'This is a new you _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 69,
+      text: 'This is a new me _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 70,
+      text: 'This is a new us _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 71,
+      text: 'Soukous is to _ as Swahili is to _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 72,
+      text: 'czar is the coomon to _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Asia'
+    },
+    {
+      id: 73,
+      text: 'Africas are _ and Europeans are _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'America'
+    },
+    {
+      id: 74,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 75,
+      text: 'That is a new we _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 77,
+      text: 'This is a new them _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 78,
+      text: 'This is a new you _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 79,
+      text: 'This is a new me _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 80,
+      text: 'This is a new us _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 81,
+      text: 'Soukous is to _ as Swahili is to _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 82,
+      text: 'czar is the coomon to _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Asia'
+    },
+    {
+      id: 83,
+      text: 'Africas are _ and Europeans are _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'America'
+    },
+    {
+      id: 84,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 85,
+      text: 'That is a new we _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 26,
+      text: 'That is a new we _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 87,
+      text: 'This is a new them _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 88,
+      text: 'This is a new you _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 89,
+      text: 'This is a new me _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 90,
+      text: 'This is a new us _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 91,
+      text: 'Soukous is to _ as Swahili is to _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 92,
+      text: 'czar is the coomon to _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Asia'
+    },
+    {
+      id: 93,
+      text: 'Africas are _ and Europeans are _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'America'
+    },
+    {
+      id: 94,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 95,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 96,
+      text: 'That is a new we _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 97,
+      text: 'This is a new them _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }, {
+      id: 98,
+      text: 'This is a new you _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }, {
+      id: 99,
+      text: 'This is a new me _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }, {
+      id: 100,
+      text: 'This is a new us _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 101,
+      text: 'Soukous is to _ as Swahili is to _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 102,
+      text: 'czar is the coomon to _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Asia'
+    },
+    {
+      id: 103,
+      text: 'Africas are _ and Europeans are _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'America'
+    },
+    {
+      id: 104,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 105,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 106,
+      text: 'That is a new we _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 107,
+      text: 'This is a new them _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }, {
+      id: 108,
+      text: 'This is a new you _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }, {
+      id: 109,
+      text: 'This is a new me _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }, {
+      id: 110,
+      text: 'This is a new us _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 111,
+      text: 'Soukous is to _ as Swahili is to _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 112,
+      text: 'czar is the coomon to _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Asia'
+    },
+    {
+      id: 113,
+      text: 'Africas are _ and Europeans are _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'America'
+    },
+    {
+      id: 114,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 115,
+      text: 'This is just a _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 116,
+      text: 'That is a new we _ ',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 117,
+      text: 'This is a new them _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }, {
+      id: 118,
+      text: 'This is a new you _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 119,
+      text: 'This is a new me _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    },
+    {
+      id: 120,
+      text: 'This is a new us _',
+      numAnswers: 1,
+      official: true,
+      expansion: 'expansion',
+      location: 'Africa'
+    }
+  ];
+  Answers.remove({}, () => {
+    answers.map((answer) => {
+      const newQuestion = new Answers(answer);
+      newQuestion.save();
+      console.log('Answers collection added');
+    });
+  });
+};
+
+export default AnsersMigration;

--- a/app/seeders/questions.js
+++ b/app/seeders/questions.js
@@ -1,0 +1,930 @@
+/* eslint-disable */
+import QuestionModel from '../models/question'
+
+const questionMigration = () => {
+      const questions = [
+            {
+                  id: 1,
+                  text: 'Soukous is to _ as Swahili is to _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 2,
+                  text: 'czar is the coomon to _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Asia'
+            },
+            {
+                  id: 3,
+                  text: 'Africas are _ and Europeans are _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'America'
+            },
+            {
+                  id: 4,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 6,
+                  text: 'That is a new we _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 7,
+                  text: 'This is a new them _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 8,
+                  text: 'This is a new you _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 9,
+                  text: 'This is a new me _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 10,
+                  text: 'This is a new us _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 11,
+                  text: 'Soukous is to _ as Swahili is to _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 12,
+                  text: 'czar is the coomon to _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Asia'
+            },
+            {
+                  id: 13,
+                  text: 'Africas are _ and Europeans are _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'America'
+            },
+            {
+                  id: 14,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 15,
+                  text: 'That is a new we _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 17,
+                  text: 'This is a new them _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 18,
+                  text: 'This is a new you _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 19,
+                  text: 'This is a new me _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 20,
+                  text: 'This is a new us _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 21,
+                  text: 'Soukous is to _ as Swahili is to _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 22,
+                  text: 'czar is the coomon to _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Asia'
+            },
+            {
+                  id: 23,
+                  text: 'Africas are _ and Europeans are _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'America'
+            },
+            {
+                  id: 24,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 25,
+                  text: 'That is a new we _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 26,
+                  text: 'That is a new we _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 27,
+                  text: 'This is a new them _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 28,
+                  text: 'This is a new you _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 29,
+                  text: 'This is a new me _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 30,
+                  text: 'This is a new us _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 31,
+                  text: 'Soukous is to _ as Swahili is to _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 32,
+                  text: 'czar is the coomon to _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Asia'
+            },
+            {
+                  id: 33,
+                  text: 'Africas are _ and Europeans are _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'America'
+            },
+            {
+                  id: 34,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 35,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 36,
+                  text: 'That is a new we _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 37,
+                  text: 'This is a new them _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }, {
+                  id: 38,
+                  text: 'This is a new you _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }, {
+                  id: 39,
+                  text: 'This is a new me _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }, {
+                  id: 40,
+                  text: 'This is a new us _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 41,
+                  text: 'Soukous is to _ as Swahili is to _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 42,
+                  text: 'czar is the coomon to _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Asia'
+            },
+            {
+                  id: 43,
+                  text: 'Africas are _ and Europeans are _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'America'
+            },
+            {
+                  id: 44,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 45,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 46,
+                  text: 'That is a new we _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 47,
+                  text: 'This is a new them _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }, {
+                  id: 48,
+                  text: 'This is a new you _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }, {
+                  id: 49,
+                  text: 'This is a new me _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }, {
+                  id: 50,
+                  text: 'This is a new us _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 51,
+                  text: 'Soukous is to _ as Swahili is to _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 52,
+                  text: 'czar is the coomon to _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Asia'
+            },
+            {
+                  id: 53,
+                  text: 'Africas are _ and Europeans are _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'America'
+            },
+            {
+                  id: 54,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 55,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 56,
+                  text: 'That is a new we _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 57,
+                  text: 'This is a new them _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }, {
+                  id: 58,
+                  text: 'This is a new you _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 59,
+                  text: 'This is a new me _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 60,
+                  text: 'This is a new us _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 61,
+                  text: 'Soukous is to _ as Swahili is to _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 61,
+                  text: 'czar is the coomon to _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Asia'
+            },
+            {
+                  id: 63,
+                  text: 'Africas are _ and Europeans are _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'America'
+            },
+            {
+                  id: 64,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 64,
+                  text: 'That is a new we _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 67,
+                  text: 'This is a new them _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 68,
+                  text: 'This is a new you _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 69,
+                  text: 'This is a new me _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 70,
+                  text: 'This is a new us _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 71,
+                  text: 'Soukous is to _ as Swahili is to _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 72,
+                  text: 'czar is the coomon to _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Asia'
+            },
+            {
+                  id: 73,
+                  text: 'Africas are _ and Europeans are _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'America'
+            },
+            {
+                  id: 74,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 75,
+                  text: 'That is a new we _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 77,
+                  text: 'This is a new them _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 78,
+                  text: 'This is a new you _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 79,
+                  text: 'This is a new me _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 80,
+                  text: 'This is a new us _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 81,
+                  text: 'Soukous is to _ as Swahili is to _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 82,
+                  text: 'czar is the coomon to _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Asia'
+            },
+            {
+                  id: 83,
+                  text: 'Africas are _ and Europeans are _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'America'
+            },
+            {
+                  id: 84,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 85,
+                  text: 'That is a new we _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 26,
+                  text: 'That is a new we _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 87,
+                  text: 'This is a new them _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 88,
+                  text: 'This is a new you _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 89,
+                  text: 'This is a new me _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 90,
+                  text: 'This is a new us _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 91,
+                  text: 'Soukous is to _ as Swahili is to _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 92,
+                  text: 'czar is the coomon to _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Asia'
+            },
+            {
+                  id: 93,
+                  text: 'Africas are _ and Europeans are _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'America'
+            },
+            {
+                  id: 94,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 95,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 96,
+                  text: 'That is a new we _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 97,
+                  text: 'This is a new them _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }, {
+                  id: 98,
+                  text: 'This is a new you _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }, {
+                  id: 99,
+                  text: 'This is a new me _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }, {
+                  id: 100,
+                  text: 'This is a new us _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 101,
+                  text: 'Soukous is to _ as Swahili is to _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 102,
+                  text: 'czar is the coomon to _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Asia'
+            },
+            {
+                  id: 103,
+                  text: 'Africas are _ and Europeans are _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'America'
+            },
+            {
+                  id: 104,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 105,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 106,
+                  text: 'That is a new we _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 107,
+                  text: 'This is a new them _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }, {
+                  id: 108,
+                  text: 'This is a new you _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }, {
+                  id: 109,
+                  text: 'This is a new me _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }, {
+                  id: 110,
+                  text: 'This is a new us _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 111,
+                  text: 'Soukous is to _ as Swahili is to _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 112,
+                  text: 'czar is the coomon to _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Asia'
+            },
+            {
+                  id: 113,
+                  text: 'Africas are _ and Europeans are _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'America'
+            },
+            {
+                  id: 114,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 115,
+                  text: 'This is just a _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 116,
+                  text: 'That is a new we _ ',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 117,
+                  text: 'This is a new them _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }, {
+                  id: 118,
+                  text: 'This is a new you _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 119,
+                  text: 'This is a new me _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            },
+            {
+                  id: 120,
+                  text: 'This is a new us _',
+                  numAnswers: 1,
+                  official: true,
+                  expansion: 'expansion',
+                  location: 'Africa'
+            }
+      ];
+      QuestionModel.remove({}, () => {
+            questions.map((question) => {
+                  const newQuestion = new QuestionModel(question);
+                  newQuestion.save();
+                  console.log("questions collection added");
+            });
+      });
+}
+
+export default questionMigration;

--- a/app/views/includes/foot.jade
+++ b/app/views/includes/foot.jade
@@ -22,6 +22,10 @@ script(type='text/javascript', src='https://cdn.firebase.com/libs/angularfire/1.
 // Emojinarea
 script(type='text/javascript', src='https://cdnjs.cloudflare.com/ajax/libs/emojionearea/3.2.6/emojionearea.js')
 
+// Firebase
+script(type='text/javascript', src='https://cdn.firebase.com/js/client/2.1.2/firebase.js')
+script(type='text/javascript', src='https://cdn.firebase.com/libs/angularfire/1.0.0/angularfire.min.js')
+
 //Angular UI
 script(type='text/javascript', src='/lib/angular-bootstrap/ui-bootstrap-tpls.js')
 script(type='text/javascript', src='/lib/angular-ui-utils/modules/route.js')

--- a/app/views/includes/head.jade
+++ b/app/views/includes/head.jade
@@ -25,7 +25,7 @@ head
   link(rel='stylesheet', href='/css/chat.css')
   link(rel='stylesheet', href='https://cdnjs.cloudflare.com/ajax/libs/emojionearea/3.2.6/emojionearea.css')
 
-  link(href='/assets/bootstrap/css/bootstrap.min.css', rel='stylesheet', type='text/css')
+  link(href='/assets/bootstrap/css/bootstrap.css', rel='stylesheet', type='text/css')
   link(href='/assets/icons/lines/init.css', rel='stylesheet' type='text/css')
   link(href='/assets/fonts/opensans/init.css', rel='stylesheet', type='text/css')
   link(href='/assets/fonts/tangerine/init.css', rel='stylesheet', type='text/css')

--- a/config/jwt.js
+++ b/config/jwt.js
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-unresolved, import/extensions */
+/* eslint-disable import/no-unresolved, import/extensions, no-unused-vars */
 import jwt from 'jsonwebtoken';
 import { tokenSecret } from '../config/env/all';
 
@@ -28,3 +28,15 @@ export const signUser = (user) => {
   return jwt.sign(user, token);
 };
 
+export const isLoggedIn = (req, res, next) => {
+  const token = req.headers.auth;
+  jwt.verify(token, tokenSecret, (err, result) => {
+    if (err) {
+      return res.status(401).json({
+        success: false,
+        message: 'Failed to authenticate token'
+      });
+    }
+    next();
+  });
+};

--- a/config/routes.js
+++ b/config/routes.js
@@ -1,5 +1,9 @@
-/* eslint-disable max-len, global-require, import/no-unresolved */
-module.exports = (app, passport) => {
+/*  eslint-disable */
+import async from 'async';
+import { createGame } from '../app/controllers/gameHistory';
+import { isLoggedIn } from '../config/jwt';
+
+const route = (app, passport, auth) => {
   // User Routes
   const users = require('../app/controllers/users');
   app.get('/signin', users.signin);
@@ -7,11 +11,13 @@ module.exports = (app, passport) => {
   app.get('/chooseavatars', users.checkAvatar);
 
   app.get('/signout', users.signout);
-  app.post('/api/auth/signup', users.createJwt);
-  app.post('/api/auth/signin', users.loginJwt);
   // Setting up the users api
   app.post('/users', users.create);
   app.post('/users/avatars', users.avatars);
+
+  app.get('/signout', users.signout);
+  app.post('/api/auth/signup', users.createJwt);
+  app.post('/api/auth/signin', users.loginJwt);
 
   // Donation Routes
   app.post('/donations', users.addDonation);
@@ -85,4 +91,9 @@ module.exports = (app, passport) => {
   app.get('/', index.render);
   app.get('/api/search/users', users.searchUser);
   app.post('/api/users/invite', users.inviteUser);
+
+  // game route
+  app.post('/api/games/:id/start', isLoggedIn, createGame);
 };
+
+export default route;

--- a/config/socket/game.js
+++ b/config/socket/game.js
@@ -1,7 +1,6 @@
 /* eslint-disable max-len, import/no-dynamic-require, func-names, prefer-destructuring, no-plusplus, no-underscore-dangle, import/no-unresolved, no-use-before-define */
 const async = require('async');
 const _ = require('underscore');
-
 const answers = require(`${__dirname}/../../app/controllers/answers.js`);
 const questions = require(`${__dirname}/../../app/controllers/questions.js`);
 const guestNames = [
@@ -236,7 +235,6 @@ Game.prototype.stateResults = function (self) {
 
 Game.prototype.stateEndGame = function (winner) {
   this.state = 'game ended';
-  this.gameWinner = winner;
   this.sendUpdate();
 };
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "async": "~0.2.9",
+    "axios": "^0.17.1",
     "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",

--- a/public/assets/bootstrap/css/bootstrap.css
+++ b/public/assets/bootstrap/css/bootstrap.css
@@ -5477,11 +5477,11 @@ button.close {
 }
 
 .modal-backdrop.fade {
-  opacity: 0;
+  opacity: 0.7;
 }
 
 .modal-backdrop.show {
-  opacity: 0.5;
+  opacity: 0.7;
 }
 
 .modal-header {
@@ -5498,6 +5498,7 @@ button.close {
       -ms-flex-pack: justify;
           justify-content: space-between;
   padding: 15px;
+  margin-bottom: 15px;
   border-bottom: 1px solid #eceeef;
 }
 

--- a/public/js/controllers/game.js
+++ b/public/js/controllers/game.js
@@ -1,6 +1,7 @@
-/* eslint-disable max-len, no-undef, no-unused-vars */
+/* eslint-disable */
+
 angular.module('mean.system')
-  .controller('GameController', ['$scope', 'game', '$timeout', '$location', 'MakeAWishFactsService', '$dialog', ($scope, game, $timeout, $location, MakeAWishFactsService, $dialog) => {
+  .controller('GameController', ['$scope', 'game', '$timeout', '$http', '$location', 'MakeAWishFactsService', '$dialog', '$window', function ($scope, game, $timeout, $http, $location, MakeAWishFactsService, $dialog, $window) {
     toastr.options = {
       positionClass: 'toast-top-full-width',
       progressBar: 'true',
@@ -16,6 +17,7 @@ angular.module('mean.system')
     $scope.showTable = false;
     $scope.modalShown = false;
     $scope.game = game;
+    $scope.gameStarted = false;
     $scope.pickedCards = [];
     $scope.searchTerm = '';
     $scope.invitedUsers = [];
@@ -120,6 +122,9 @@ angular.module('mean.system')
     $scope.abandonGame = () => {
       game.leaveGame();
       $location.path('/');
+      $('#start').modal('hide');
+      $('body').removeClass('modal-open');
+      $('.modal-backdrop').remove();
     };
 
     // Catches changes to round to update when no players pick card
@@ -135,10 +140,66 @@ angular.module('mean.system')
       $scope.pickedCards = [];
     });
 
+    $scope.loadModal = () => {
+      if (game.state === 'awaiting players') {
+        $('#start').modal({
+          show: true,
+          backdrop: 'static',
+          keyboard: false,
+        });
+        if (game.state === 'waiting for players to pick') {
+          $('#start').modal('hide');
+          $('body').removeClass('modal-open');
+          $('.modal-backdrop').remove();
+        }
+      }
+    }
+
+
     // In case player doesn't pick a card in time, show the table
     $scope.$watch('game.state', () => {
+      $scope.loadModal();
+      if (game.state === 'waiting for players to pick') {
+        $('#start').modal('hide');
+        $('body').removeClass('modal-open');
+        $('.modal-backdrop').remove();
+      }
       if (game.state === 'waiting for czar to decide' && $scope.showTable === false) {
+        $('#start').modal('hide');
+        $('body').removeClass('modal-open');
+        $('.modal-backdrop').remove();
         $scope.showTable = true;
+      }
+      if (!game.state) {
+        $('#start').modal('hide');
+        $('body').removeClass('modal-open');
+        $('.modal-backdrop').remove();
+        $scope.showTable = true;
+      }
+      if (game.state === 'game ended' && game.playerIndex === game.czar) {
+        const players = game.players.map(player => {
+          return player.username;
+        });
+        const data = {
+          gameID: game.gameID,
+          creator: game.players[0].username,
+          rounds: game.round,
+          winner: game.players[game.winningCardPlayer].username,
+          players,
+        };
+
+        const token = localStorage.getItem('token');
+
+        $http.post('/api/games/' + game.gameID + '/start', data, {
+          headers: {
+            auth: token
+          }
+        })
+          .success(function (response) {
+            console.log(response);
+          }).error(function (error) {
+            console.log(error);
+          });
       }
     });
 
@@ -166,7 +227,6 @@ angular.module('mean.system')
         }
       }
     });
-
 
     if ($location.search().game && !(/^\d+$/).test($location.search().game)) {
       game.joinGame('joinGame', $location.search().game);

--- a/public/views/adds.html
+++ b/public/views/adds.html
@@ -1,4 +1,4 @@
 <div style="margin-left: 40px; margin-right: 40px; margin-top:10px;">
-    <div style="width:100%; min-height: 70px; background-image: url('/img/giphy.gif')">
+    <div style="width:100%; min-height: 70px; background-color: #ccc;">
     </div>
 </div>

--- a/public/views/answers.html
+++ b/public/views/answers.html
@@ -1,3 +1,8 @@
+
+<div style="margin-top: 70px; margin-bottom: -70px; width: 100%;">
+  <div style="width:100%; min-height: 90px; background-image: url('/img/bet.png'); margin-bottom: 100px; clear: both;"></div>
+</div>
+
 <div style="margin-top: 70px; margin-bottom: -70px; width: 100%;">
   <div style="width:100%; min-height: 90px; background-image: url('/img/bet.png'); margin-bottom: 100px; clear: both;"></div>
 </div>
@@ -32,8 +37,8 @@
 
 <div id="info-container" ng-show="game.state === 'awaiting players'" style="margin-top:80px; background-color:rgb(58, 64, 80);">
   <div id="inner-info">
-    <div id="">How To Play</div>
-    <ol id="">
+    <div id="lobby-how-to-play">How To Play</div>
+    <ol id="oh-el">
 
       <li>Each player begins with, and will always have, 10 white answer cards.</li>
       <li>For each round, one player is randomly chosen as the Card Czar.</li>

--- a/public/views/app.html
+++ b/public/views/app.html
@@ -224,6 +224,6 @@
         </i>
       </div>
     </div>
-
+    <div ng-include src='"/views/partials/start.html"'></div>
   </div>
 </div>

--- a/public/views/partials/signin.html
+++ b/public/views/partials/signin.html
@@ -5,6 +5,7 @@
     </a>
     <div class='clear'></div>
 </h4>
+<h4 class="su-heading">Sign In</h4>
 <h6 class="su-heading-small">Sign-In to your account for authentication</h6>
 <div class="row">
     <div class="col-6">
@@ -14,10 +15,20 @@
                 <span class="float-left">Signin with Facebook</span>
                 <div class="clear"></div>
             </span>
+            <span class="signup-social fb-bg">
+                <i class="fa fa-facebook float-left"></i>
+                <span class="float-left">Signin with Facebook</span>
+                <div class="clear"></div>
+            </span>
         </a>
     </div>
     <div class="col-6">
         <a href="/auth/github">
+            <span class="signup-social gh-bg">
+                <i class="fa fa-github float-left"></i>
+                <span class="float-left">Signin with Github</span>
+                <div class="clear"></div>
+            </span>
             <span class="signup-social gh-bg">
                 <i class="fa fa-github float-left"></i>
                 <span class="float-left">Signin with Github</span>
@@ -34,6 +45,11 @@
                 <span class="float-left">Signin with Google</span>
                 <div class="clear"></div>
             </span>
+            <span class="signup-social gg-bg">
+                <i class="fa fa-google float-left"></i>
+                <span class="float-left">Signin with Google</span>
+                <div class="clear"></div>
+            </span>
         </a>
     </div>
     <div class="col-6">
@@ -43,8 +59,17 @@
                 <span class="float-left">Signin with Twitter</span>
                 <div class="clear"></div>
             </span>
+            <span class="signup-social tw-bg">
+                <i class="fa fa-twitter float-left"></i>
+                <span class="float-left">Signin with Twitter</span>
+                <div class="clear"></div>
+            </span>
         </a>
     </div>
+</div>
+<div class="mt-3 row" ng-init='init()'>
+    </a>
+</div>
 </div>
 <div class="row" ng-init='init()'>
     <div class="col-12">
@@ -61,6 +86,13 @@
         </div>
         <div>
             <button class="float-left butA su-button" ng-click='signin()'>SIGN IN</button>
+            <a href="#">
+                <span class="float-right" id="signin-forgot">FORGOT PASSWORD</span>
+            </a>
+
+            <a href="#">
+                <span class="float-right" id="signin-forgot">FORGOT PASSWORD</span>
+            </a>
             <a href="#">
                 <span class="float-right" id="signin-forgot">FORGOT PASSWORD</span>
             </a>

--- a/public/views/partials/start.html
+++ b/public/views/partials/start.html
@@ -1,0 +1,45 @@
+<div id="startGame" style="opacity: 1" ng-init="loadModal()" ng-show="game.state === 'awaiting players' || game.playerIndex === 0 || game.joinOverride">
+  <div id="start" class="modal fade" style="opacity: 1; z-index: 20000; position:absolute; top: 50px;" role="dialog">
+    <div class="modal-dialog">
+      <div class="modal-content">
+
+        <div ng-model="game" class="modal-body text-center">
+          <div class="modal-header">
+            <h4 class="text-center">Card For Humanity</h4>
+          </div>
+
+          <h4 style="font-weight:bold; border-bottom: 1px solid #ccc; padding-bottom: 15px; padding-top: 15px; color:rgb(29, 28, 28)">Cards For Humanity</h4>
+          <span style="top: 10px;">
+            <br/>
+            <button ng-hide="game.playerIndex !== 0" ng-disabled="game.players.length < 3" ng-click="startGame()" class="btn" data-dismiss="modal"
+              style="color:#fff; background-color:green">Start Game</button>
+          </span>
+          <span>
+            <button ng-hide="game.playerIndex !== 0" ng-disabled="game.players.length >= 12" data-toggle="modal" data-target="#myModal"
+              class="btn" style="color:#fff; background-color:blue">Invite Players</button>
+          </span>
+          <br/>
+          <br/>
+          <figcaption>
+            <span style="font-weight:bolder">You need at least three players to start the game</span>
+            <br /> Finding Players
+            <span style="color: green">{{game.notification}}</span>
+            <br />
+            <br />
+            <div id="loading-container">
+              <div id="loading-gif">
+                <img ng-src="../img/loader.gif" />
+              </div>
+            </div>
+            <span ng-show="game.players.length >= 3">Waiting for {{game.players[0].username}} to start the game
+              <br>
+            </span>
+            <br>{{game.players.length}} players found</figcaption>
+        </div>
+        <div class="modal-footer">
+          <button id="close" type="button" ng-click="abandonGame()" class="btn btn-danger" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/public/views/player.html
+++ b/public/views/player.html
@@ -1,4 +1,4 @@
-<div id="player-conainer" ng-repeat="player in game.players" style="background-color: {{colors[player.color]}}; border-radius:50px; padding:5px; margin-bottom:10px;">
+<div id="player-conainer" ng-repeat="player in game.players" style="background-color: {{colors[player.color]}}; border-radius:50px; padding:5px; margin-bottom:10px; box-shadow: 1px 2px #888;">
   <div id ="above-czar-container" style="display:flex; flex-basis:1 1; flex-shrink:1;">
     <div id="avatar_" style="height:30px;">
       <span ng-show="isPremium($index)">

--- a/public/views/question.html
+++ b/public/views/question.html
@@ -1,5 +1,6 @@
 <!-- {{ game.state }} -->
 <div>
+  <start></start>
   <div id="startGameModal" class="modal fade">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -171,8 +172,7 @@
           </i>
         </div>
       </div>
-  </div>
-
-
+  </div> 
 </div>
 
+<div ng-include='"/views/partials/start.html"'></div>

--- a/server.js
+++ b/server.js
@@ -16,7 +16,9 @@ import config from './config/config';
 import auth from './config/middlewares/authorization';
 import routes from './config/routes';
 import expressConfig from './config/express';
-import passportConfig from './config/passport';
+// import QuestionModel from './app/seeders/questions';
+// import AnsersMigration from './app/seeders/answers';
+
 
 dotenv.config();
 
@@ -47,7 +49,7 @@ const walk = (path) => {
 walk(modelsPath);
 
 // bootstrap passport config
-passportConfig(passport);
+// passportConfig(passport);
 
 const app = express();
 
@@ -71,6 +73,9 @@ require('./config/socket/socket')(ioObj);
 
 // Initializing logger
 logger.init(app, passport, mongoose);
+
+// QuestionModel();
+// AnsersMigration();
 
 // expose app
 export default app;

--- a/test/user/user.js
+++ b/test/user/user.js
@@ -62,106 +62,106 @@ describe('Invite user', () => {
 });
 
 // describe('POST Test suites for User sign up', () => {
-//   describe('validation test', () => {
-//     it('should return \'Please enter your credentials\' when user omits name field', (done) => {
-//       request.post('/api/auth/signup')
-//         .set('Accept', 'application/json')
-//         .send({
-//           email: 'moh@gmail.com',
-//           username: 'moksty'
-//         })
-//         .end((err, res) => {
-//           expect(res.statusCode).to.equal(400);
-//           expect(res.body.message).to.equal('Please enter your credentials');
-//           done();
-//         });
-//     });
+  // describe('validation test', () => {
+    // it('should return \'Please enter your credentials\' when user omits name field', (done) => {
+    //   request.post('/api/auth/signup')
+    //     .set('Accept', 'application/json')
+    //     .send({
+    //       email: 'moh@gmail.com',
+    //       username: 'moksty'
+    //     })
+    //     .end((err, res) => {
+    //       expect(res.statusCode).to.equal(400);
+    //       expect(res.body.message).to.equal('Please enter your credentials');
+    //       done();
+    //     });
+    // });
 
-//     it('should return \'Please enter your credentials\' when user omits email field', (done) => {
-//       request.post('/api/auth/signup')
-//         .set('Accept', 'application/json')
-//         .send({
-//           name: 'Isioye Mohammed',
-//           username: 'moksty'
-//         })
-//         .end((err, res) => {
-//           expect(res.statusCode).to.equal(400);
-//           expect(res.body.message).to.equal('Please enter your credentials');
-//           done();
-//         });
-//     });
+    // it('should return \'Please enter your credentials\' when user omits email field', (done) => {
+    //   request.post('/api/auth/signup')
+    //     .set('Accept', 'application/json')
+    //     .send({
+    //       name: 'Isioye Mohammed',
+    //       username: 'moksty'
+    //     })
+    //     .end((err, res) => {
+    //       expect(res.statusCode).to.equal(400);
+    //       expect(res.body.message).to.equal('Please enter your credentials');
+    //       done();
+    //     });
+    // });
 
-//     it('should return \'Please enter your credentials\' when user omits username field', (done) => {
-//       request.post('/api/auth/signup')
-//         .set('Accept', 'application/json')
-//         .send({
-//           name: 'Isioye Mohammed',
-//           email: 'moh@gmail.com'
-//         })
-//         .end((err, res) => {
-//           expect(res.statusCode).to.equal(400);
-//           expect(res.body.message).to.equal('Please enter your credentials');
-//           done();
-//         });
-//     });
+    // it('should return \'Please enter your credentials\' when user omits username field', (done) => {
+    //   request.post('/api/auth/signup')
+    //     .set('Accept', 'application/json')
+    //     .send({
+    //       name: 'Isioye Mohammed',
+    //       email: 'moh@gmail.com'
+    //     })
+    //     .end((err, res) => {
+    //       expect(res.statusCode).to.equal(400);
+    //       expect(res.body.message).to.equal('Please enter your credentials');
+    //       done();
+    //     });
+    // });
 
-//     it('should return \'Please enter your credentials\' when user omits password field', (done) => {
-//       request.post('/api/auth/signup')
-//         .set('Accept', 'application/json')
-//         .send({
-//           name: 'Isioye Mohammed',
-//           email: 'moh@gmail.com',
-//           username: 'moksty'
-//         })
-//         .end((err, res) => {
-//           expect(res.statusCode).to.equal(400);
-//           expect(res.body.message).to.equal('Please enter your credentials');
-//           done();
-//         });
-//     });
-//   });
+    // it('should return \'Please enter your credentials\' when user omits password field', (done) => {
+    //   request.post('/api/auth/signup')
+    //     .set('Accept', 'application/json')
+    //     .send({
+    //       name: 'Isioye Mohammed',
+    //       email: 'moh@gmail.com',
+    //       username: 'moksty'
+    //     })
+    //     .end((err, res) => {
+    //       expect(res.statusCode).to.equal(400);
+    //       expect(res.body.message).to.equal('Please enter your credentials');
+    //       done();
+    //     });
+    // });
+  // });
 // });
 
 // describe('Test suite for user login', () => {
-//   it('should return "Please enter your credentials" if email or password fields are empty', (done) => {
-//     request.post('/api/auth/signin')
-//     .set('Accept', 'application/json')
-//     .send({
-//       email: '',
-//       password: '',
-//     })
-//     .end((err, res) => {
-//       expect(res.statusCode).to.equal(400);
-//       expect(res.body.message).to.equal('Please enter your credentials');
-//       done();
-//     });
-//   });
+  // it('should return "Please enter your credentials" if email or password fields are empty', (done) => {
+  //   request.post('/api/auth/signin')
+  //   .set('Accept', 'application/json')
+  //   .send({
+  //     email: '',
+  //     password: '',
+  //   })
+  //   .end((err, res) => {
+  //     expect(res.statusCode).to.equal(400);
+  //     expect(res.body.message).to.equal('Please enter your credentials');
+  //     done();
+  //   });
+  // });
 
-//   it('should return "Please enter valid email" if email format is incorrect', (done) => {
-//     request.post('/api/auth/signin')
-//     .set('Accept', 'application/json')
-//     .send({
-//       email: 'buharigmail.com',
-//       password: 'password',
-//     })
-//     .end((err, res) => {
-//       expect(res.statusCode).to.equal(422);
-//       expect(res.body.message).to.equal('Please enter valid email');
-//       done();
-//     });
-//   });
+  // it('should return "Please enter valid email" if email format is incorrect', (done) => {
+  //   request.post('/api/auth/signin')
+  //   .set('Accept', 'application/json')
+  //   .send({
+  //     email: 'buharigmail.com',
+  //     password: 'password',
+  //   })
+  //   .end((err, res) => {
+  //     expect(res.statusCode).to.equal(422);
+  //     expect(res.body.message).to.equal('Please enter valid email');
+  //     done();
+  //   });
+  // });
 
-//   it('should return "Invalid Credentials" if password is incorrect', (done) => {
-//     request.post('/api/auth/signin')
-//     .set('Accept', 'application/json')
-//     .send({
-//       email: fakerEmail,
-//       password: fakerPassword + 'ioubjbf',
-//     })
-//     .end((err, res) => {
-//       expect(res.statusCode).to.equal(401);
-//       expect(res.body.message).to.equal('Incorrect username or password');
-//       done();
-//     });
-//   });
+  // it('should return "Invalid Credentials" if password is incorrect', (done) => {
+  //   request.post('/api/auth/signin')
+  //   .set('Accept', 'application/json')
+  //   .send({
+  //     email: fakerEmail,
+  //     password: fakerPassword + 'ioubjbf',
+  //   })
+  //   .end((err, res) => {
+  //     expect(res.statusCode).to.equal(401);
+  //     expect(res.body.message).to.equal('Incorrect username or password');
+  //     done();
+  //   });
+  // });
 // });


### PR DESCRIPTION
#### What does this PR do?
user should be able to create/start a new game

#### Description of Task to be completed?
As a registered user I should be able to create or start a new game session, and the game log of a completed game session persisted in the database to be viewed on a later date.

#### How should this be manually tested?
- Clone the repository
- Run `npm install`
- Run `git checkout feature/153009258/start-game`
- Run `npm start`
- signup or signin
- click the start game button to start the game using the new modal feature
- play the game to the end of the session as a logged in user to save a game session log

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
- story type: feature
- story id: 153009258
- story title: Users should be able to create/start a new game

#### Screenshots (if appropriate)
<img width="1440" alt="screen shot 2017-12-15 at 2 17 32 am" src="https://user-images.githubusercontent.com/14099353/34022216-3dfc7254-e13e-11e7-9d3c-53d6bc2f452f.png">

#### Questions:
N/A